### PR TITLE
Add information about events

### DIFF
--- a/pages/contributions/index.md
+++ b/pages/contributions/index.md
@@ -13,6 +13,7 @@ Every data source in Savannah determines what activity in that source should be 
 | Slack          | Help given in chat to another member (as suggested by Savannah) |
 | Discourse      | Posts marked as a Solution using Discourse's Answers plugin |
 | Discord        | Help given in chat to another member (as suggested by Savannah) |
+| Event          | Organising or speaking at an event |
 | Github         | Pull Request opened |
 | Gitlab         | Merge Request opened |
 | Stack Exchange | Accepted answers to a question |


### PR DESCRIPTION
Add that speaking or hosting events is considered a contribution.

Wasn't really sure where to add docs about events, as I think there's plans to expand this to include meetup.com events, so just left it at this to start with :) 